### PR TITLE
don't send values if the device isn't assembled

### DIFF
--- a/device/oc_auth.lsl
+++ b/device/oc_auth.lsl
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
 
- Auth, Build 186
+ Auth, Build 187
 
  Wendy's OpenCollar Distribution
  https://github.com/wendystarfall/opencollar
@@ -88,7 +88,7 @@
 
 ------------------------------------------------------------------------------*/
 
-integer g_iBuild = 186;
+integer g_iBuild = 187;
 
 string g_sWearerID;
 list g_lOwner;
@@ -308,7 +308,6 @@ AddUniquePerson(string sPersonID, string sToken, key kID) {
 }
 
 SayOwners() {
-    if (llGetObjectDesc() == "Wendy's Updater") return;
     integer iCount = llGetListLength(g_lOwner);
     if (iCount || g_iVanilla) {
         integer index;

--- a/device/oc_settings.lsl
+++ b/device/oc_settings.lsl
@@ -1,6 +1,6 @@
 /*------------------------------------------------------------------------------
 
- Settings, Build 111
+ Settings, Build 112
 
  Wendy's OpenCollar Distribution
  https://github.com/wendystarfall/opencollar
@@ -86,7 +86,7 @@
 
 ------------------------------------------------------------------------------*/
 
-integer g_iBuild = 111;
+integer g_iBuild = 112;
 
 string g_sCard = ".settings";
 string g_sSplitLine;
@@ -300,6 +300,7 @@ LoadSetting(string sData, integer iLine) {
 }
 
 SendValues() {
+    if (llGetNumberOfPrims() < 6) return;
     integer n;
     string sToken;
     list lOut;


### PR DESCRIPTION
This is done to prevent irritating notifies during build processes. Now
we can remove that bandaid if clause in auth.